### PR TITLE
ImageCore 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,6 @@ authors = "JuliaImages Team"
 version = "0.1.2"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -13,9 +11,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-ColorTypes = "0.11"
-ColorVectorSpace = "0.9"
-ImageCore = "0.9"
+ImageCore = "0.9, 0.10"
 ImageFiltering = "0.7"
 PrecompileTools = "1"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1.0"

--- a/src/ImageCorners.jl
+++ b/src/ImageCorners.jl
@@ -1,7 +1,6 @@
 module ImageCorners
 
-using ColorTypes
-using ColorVectorSpace
+using ImageCore
 using ImageCore: NumberLike
 using ImageFiltering
 using PrecompileTools


### PR DESCRIPTION
Also slim down the dependencies; since ImageCore exports Colors
and loads ColorVectorSpace, there's no need to list them explicitly.

Closes #12
Closes #13
